### PR TITLE
ci: skip semantic-release if no relevant files changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       - run: npm run test
       - run: npm run build
 
+
   release:
     needs: test
     runs-on: ubuntu-latest
@@ -38,17 +39,30 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20.x
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
-      
+
       - run: npm ci
       - run: npm run build
-      
+
+      - name: Check for relevant changes
+        id: changes
+        run: |
+          git fetch origin main:main
+          CHANGED=$(git diff --name-only main...HEAD -- src/ package.json dist/)
+          echo "Changed files: $CHANGED"
+          if [ -z "$CHANGED" ]; then
+            echo "skip_release=true" >> $GITHUB_ENV
+          else
+            echo "skip_release=false" >> $GITHUB_ENV
+          fi
+
       - name: Release
+        if: env.skip_release == 'false'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This PR updates the CI pipeline to prevent unnecessary NPM releases. Semantic-release will now only run if relevant files (src/, package.json, dist/) have changed. No code or build changes are included; this is a pipeline-only adjustment and should not trigger a new release upon merge.