### PR TITLE
fix: correct release check logic to compare with previous commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,17 +52,19 @@ jobs:
       - name: Check for relevant changes
         id: changes
         run: |
-          git fetch origin main:main
-          CHANGED=$(git diff --name-only main...HEAD -- src/ package.json dist/)
+          # Compare current commit with previous commit to detect relevant changes
+          CHANGED=$(git diff --name-only HEAD~1 HEAD -- src/ package.json dist/ tsconfig.json tsup.config.ts)
           echo "Changed files: $CHANGED"
           if [ -z "$CHANGED" ]; then
-            echo "skip_release=true" >> $GITHUB_ENV
+            echo "skip_release=true" >> "$GITHUB_OUTPUT"
+            echo "No relevant changes detected, skipping release."
           else
-            echo "skip_release=false" >> $GITHUB_ENV
+            echo "skip_release=false" >> "$GITHUB_OUTPUT"
+            echo "Relevant changes detected, proceeding with release."
           fi
 
       - name: Release
-        if: env.skip_release == 'false'
+        if: steps.changes.outputs.skip_release == 'false'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Problem

The previous implementation crashed because it tried to `git fetch origin main:main` while already on the main branch, which Git refuses to do.

## Solution

- Changed to compare `HEAD~1` with `HEAD` to detect relevant file changes
- Fixed the output method from `GITHUB_ENV` to `GITHUB_OUTPUT` for proper step outputs
- Added build config files (`tsconfig.json`, `tsup.config.ts`) to the list of relevant files
- Added descriptive echo messages for better CI visibility

## Testing

This PR only modifies the CI workflow. The change detection logic now properly:
1. Compares the current commit with the previous one
2. Checks for changes in: `src/`, `package.json`, `dist/`, `tsconfig.json`, `tsup.config.ts`
3. Skips semantic-release if no relevant changes are found

Since this PR only changes the workflow file, it should NOT trigger a release when merged (which is the desired behavior).