### PR TITLE
test: fix failing tests for ADR guidelines changes

### DIFF
--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -61,7 +61,7 @@ describe('CLI End-to-End Tests', () => {
       expect(await pathExists(join(tempDir, 'docs', 'adr', 'templates', 'ADR-0000-template.md'))).toBe(true);
       expect(await pathExists(join(tempDir, '.dependency-cruiser.js'))).toBe(true);
       expect(await pathExists(join(tempDir, '.github', 'PULL_REQUEST_TEMPLATE.md'))).toBe(true);
-      expect(await pathExists(join(tempDir, 'AGENT_RULES-snippet.md'))).toBe(true);
+      expect(await pathExists(join(tempDir, 'docs', 'ADR_GUIDELINES.md'))).toBe(true);
     });
 
     it('should skip existing files on re-initialization', async () => {

--- a/tests/features/adr-init.feature
+++ b/tests/features/adr-init.feature
@@ -13,7 +13,7 @@ Feature: ADR Workspace Initialization
     And I should see "docs/adr/README.md" file
     And I should see ".dependency-cruiser.js" file
     And I should see ".github/PULL_REQUEST_TEMPLATE.md" file
-    And I should see "AGENT_RULES-snippet.md" file
+    And I should see "docs/ADR_GUIDELINES.md" file
     And the command should exit with code 0
 
   Scenario: Initialize workspace with existing files

--- a/tests/integration/workflow-integration.test.ts
+++ b/tests/integration/workflow-integration.test.ts
@@ -27,7 +27,7 @@ describe('Workflow Integration', () => {
   describe('Complete ADR Workflow', () => {
     it('should support full ADR lifecycle', async () => {
       // Step 1: Initialize workspace
-      const initResult = await initWorkspace(tempDir);
+      const initResult = await initWorkspace(tempDir, { interactive: false });
       expect(initResult.created.length).toBeGreaterThan(0);
 
       // Step 2: Create an ADR
@@ -86,7 +86,7 @@ We will use PostgreSQL as our primary database.
 
     it('should handle invalid ADR creation and correction', async () => {
       // Initialize workspace
-      await initWorkspace(tempDir);
+      await initWorkspace(tempDir, { interactive: false });
 
       // Create invalid ADR (missing required fields)
       const invalidAdr = `---
@@ -129,7 +129,7 @@ This ADR is now valid.
     });
 
     it('should handle multiple ADRs with different statuses', async () => {
-      await initWorkspace(tempDir);
+      await initWorkspace(tempDir, { interactive: false });
 
       // Create multiple ADRs with different statuses
       const adrs = [
@@ -203,7 +203,7 @@ summary: "This decision is no longer relevant."
   describe('Git Integration Workflow', () => {
     it('should validate ADR module structure without git operations', async () => {
       // Initialize ADR workspace
-      await initWorkspace(tempDir);
+      await initWorkspace(tempDir, { interactive: false });
 
       // Create ADR with module dependencies
       const adr = `---
@@ -235,7 +235,7 @@ We use React for frontend development.
     });
 
     it('should handle ADR parsing and validation correctly', async () => {
-      await initWorkspace(tempDir);
+      await initWorkspace(tempDir, { interactive: false });
 
       // Create ADR with various metadata
       const adr = `---
@@ -261,7 +261,7 @@ summary: "Choosing database technology."
     });
 
     it('should support multiple ADRs with different metadata', async () => {
-      await initWorkspace(tempDir);
+      await initWorkspace(tempDir, { interactive: false });
 
       // Create multiple ADRs with different dependencies
       const frontendAdr = `---

--- a/tests/unit/init.test.ts
+++ b/tests/unit/init.test.ts
@@ -19,12 +19,12 @@ describe('Workspace Initialization', () => {
 
   describe('initWorkspace', () => {
     it('should create all required files and directories', async () => {
-      const result = await initWorkspace(tempDir);
+      const result = await initWorkspace(tempDir, { interactive: false });
 
       expect(result.created).toContain('docs/adr/templates/ADR-0000-template.md');
       expect(result.created).toContain('.dependency-cruiser.js');
       expect(result.created).toContain('.github/PULL_REQUEST_TEMPLATE.md');
-      expect(result.created).toContain('AGENT_RULES-snippet.md');
+      expect(result.created).toContain('docs/ADR_GUIDELINES.md');
       expect(result.created).toContain('docs/adr/README.md');
 
       // Verify files actually exist
@@ -38,7 +38,7 @@ describe('Workspace Initialization', () => {
       await mkdir(join(tempDir, 'docs', 'adr'), { recursive: true });
       await writeFile(join(tempDir, '.dependency-cruiser.js'), 'Custom config');
 
-      const result = await initWorkspace(tempDir);
+      const result = await initWorkspace(tempDir, { interactive: false });
 
       expect(result.skipped).toContain('.dependency-cruiser.js');
       
@@ -49,7 +49,7 @@ describe('Workspace Initialization', () => {
     });
 
     it('should create directories recursively', async () => {
-      await initWorkspace(tempDir);
+      await initWorkspace(tempDir, { interactive: false });
 
       expect(await pathExists(join(tempDir, 'docs', 'adr', 'templates'))).toBe(true);
       expect(await pathExists(join(tempDir, '.github'))).toBe(true);
@@ -59,14 +59,14 @@ describe('Workspace Initialization', () => {
       const emptyDir = join(tempDir, 'empty');
       await mkdir(emptyDir);
 
-      const result = await initWorkspace(emptyDir);
+      const result = await initWorkspace(emptyDir, { interactive: false });
 
       expect(result.created.length).toBeGreaterThan(0);
       expect(result.skipped.length).toBe(0);
     });
 
     it('should work with absolute paths', async () => {
-      const result = await initWorkspace(tempDir);
+      const result = await initWorkspace(tempDir, { interactive: false });
       expect(result.created.length).toBeGreaterThan(0);
     });
   });


### PR DESCRIPTION
- Update unit and integration tests to expect docs/ADR_GUIDELINES.md instead of AGENT_RULES-snippet.md
- Add interactive: false option to initWorkspace calls in tests to prevent CLI prompts
- Update feature test expectations to match new file structure
- Ensure all tests pass with the new ADR guidelines implementation

## Summary

- [ ] ADRs updated as needed
- [ ] Tests added/updated

## Checklist

- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test`
- [ ] `npm run build`
