### PR TITLE
feat: Export TypeScript types for public API integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,26 @@ The toolkit also exposes programmatic helpers:
 
 Each helper accepts an optional working directory argument so you can run the tooling from scripts or tests. The `*WithConfig` variants allow you to pass custom configuration objects for advanced use cases.
 
+### TypeScript Types
+
+All key TypeScript types are exported from the main entry point for downstream tool integration:
+
+```typescript
+import type {
+  AdrIndex,
+  AdrDigest,
+  AdrDocument,
+  AdrFrontmatter,
+  CheckResult,
+  BuildResult,
+  AffectedResult,
+  ValidationError,
+  OutputFormat
+} from '@lordcraymen/adr-toolkit';
+```
+
+These types enable auto-completion and validation in TypeScript projects that consume ADR artifacts or integrate with the toolkit's API.
+
 ## Continuous Integration
 
 A reusable GitHub Actions workflow lives at `.github/workflows/ci.yml`. It runs on Node.js 18, 20, and 22 using `npm ci` followed by `lint`, `typecheck`, `test`, and `build`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+// Core functionality exports
 export * from './adr.js';
 export * from './create.js';
 export * from './init.js';
@@ -8,3 +9,21 @@ export * from './pr-comment.js';
 export * from './config.js';
 export * from './config-cli.js';
 export * from './types.js';
+
+// Explicit exports for key public API types to improve discoverability
+export type {
+  AdrIndex,
+  AdrDigest,
+  AdrIndexEntry,
+  AdrDigestEntry
+} from './adr.js';
+
+export type {
+  AdrDocument,
+  AdrFrontmatter,
+  CheckResult,
+  BuildResult,
+  AffectedResult,
+  ValidationError,
+  OutputFormat
+} from './types.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,4 @@ export * from './affected.js';
 export * from './pr-comment.js';
 export * from './config.js';
 export * from './config-cli.js';
+export * from './types.js';

--- a/tests/unit/type-exports.test.ts
+++ b/tests/unit/type-exports.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Test to verify that key TypeScript types are properly exported for downstream integrations
+ */
+
+import { describe, it, expect } from 'vitest';
+import type {
+  AdrIndex,
+  AdrDigest,
+  AdrIndexEntry,
+  AdrDigestEntry,
+  AdrDocument,
+  AdrFrontmatter,
+  CheckResult,
+  BuildResult,
+  AffectedResult,
+  ValidationError,
+  OutputFormat
+} from '../../src/index.js';
+
+describe('Type Exports for Public API', () => {
+  it('should export AdrIndex type for downstream tools', () => {
+    const exampleIndex: AdrIndex = {
+      generatedAt: new Date().toISOString(),
+      total: 0,
+      adrs: []
+    };
+    
+    expect(exampleIndex).toBeDefined();
+    expect(typeof exampleIndex.generatedAt).toBe('string');
+    expect(typeof exampleIndex.total).toBe('number');
+    expect(Array.isArray(exampleIndex.adrs)).toBe(true);
+  });
+
+  it('should export AdrDigest type for downstream tools', () => {
+    const exampleDigest: AdrDigest = {
+      generatedAt: new Date().toISOString(),
+      count: 0,
+      adrs: []
+    };
+    
+    expect(exampleDigest).toBeDefined();
+    expect(typeof exampleDigest.generatedAt).toBe('string');
+    expect(typeof exampleDigest.count).toBe('number');
+    expect(Array.isArray(exampleDigest.adrs)).toBe(true);
+  });
+
+  it('should export AdrDocument type for downstream tools', () => {
+    const exampleDocument: AdrDocument = {
+      id: 'ADR-0001',
+      title: 'Example ADR',
+      status: 'accepted',
+      summary: 'This is an example',
+      tags: [],
+      modules: [],
+      path: '/absolute/path/to/adr',
+      relativePath: 'docs/adr/ADR-0001-example.md',
+      body: 'Content of the ADR'
+    };
+    
+    expect(exampleDocument).toBeDefined();
+    expect(exampleDocument.id).toBe('ADR-0001');
+    expect(Array.isArray(exampleDocument.tags)).toBe(true);
+  });
+
+  it('should export CheckResult type for CLI integrations', () => {
+    const exampleResult: CheckResult = {
+      ok: true,
+      adrCount: 5
+    };
+    
+    expect(exampleResult).toBeDefined();
+    expect(typeof exampleResult.ok).toBe('boolean');
+    expect(typeof exampleResult.adrCount).toBe('number');
+  });
+
+  it('should export BuildResult type for CLI integrations', () => {
+    const exampleResult: BuildResult = {
+      ok: true,
+      adrCount: 5,
+      artifactsGenerated: ['index.json', 'ACTIVE.md']
+    };
+    
+    expect(exampleResult).toBeDefined();
+    expect(typeof exampleResult.ok).toBe('boolean');
+    expect(Array.isArray(exampleResult.artifactsGenerated)).toBe(true);
+  });
+
+  it('should export OutputFormat type for CLI integrations', () => {
+    const jsonFormat: OutputFormat = 'json';
+    const textFormat: OutputFormat = 'text';
+    
+    expect(jsonFormat).toBe('json');
+    expect(textFormat).toBe('text');
+  });
+});


### PR DESCRIPTION
## Summary

Export TypeScript types for emitted artifacts to improve downstream tool integration and auto-completion support.

## Changes

- ✅ Export types module from main entry point ()
- ✅ Add explicit type exports for key public API interfaces:
  - ,  - For artifact consumption
  - ,  - For entry-level integrations
  - ,  - For document processing
  - , ,  - For CLI integrations
  - ,  - For error handling and formatting
- ✅ Add comprehensive tests to verify type exports work correctly
- ✅ Update README with TypeScript types documentation section
- ✅ Include import example for downstream consumers

## Impact

Downstream tools can now:
- Import and use TypeScript types for auto-completion
- Validate integrations against official type definitions
- Build type-safe tooling around ADR artifacts
- Access proper IntelliSense support in IDEs

## Testing

- All existing tests pass ✅
- New test suite verifies type exports functionality ✅
- Build generates correct TypeScript declaration files ✅

Resolves #18